### PR TITLE
(minor) make package.json script cmds less verbose

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
         "yui-lint": "~0.1.3"
     },
     "scripts": {
-        "cover": "node node_modules/istanbul/lib/cli.js cover -- ./node_modules/mocha/bin/_mocha tests/lib/*.js --reporter spec",
-        "lint": "node node_modules/.bin/jshint --config ./node_modules/yui-lint/jshint.json ./lib/*.js tests/lib/*.js",
-        "pretest": "node node_modules/.bin/jshint --config ./node_modules/yui-lint/jshint.json ./lib/*.js tests/lib/*.js",
-        "test": "node node_modules/.bin/_mocha tests/lib/*.js --reporter spec"
+        "cover": "istanbul cover -- _mocha tests/lib/*.js --reporter spec",
+        "lint": "jshint --config node_modules/yui-lint/jshint.json lib/*.js tests/lib/*.js",
+        "pretest": "jshint --config node_modules/yui-lint/jshint.json lib/*.js tests/lib/*.js",
+        "test": "_mocha tests/lib/*.js --reporter spec"
     }
 }


### PR DESCRIPTION
(npm puts node_modules/.bin in $PATH for scripts)
