### PR TITLE
fix endless loop when locator.location isn't specified

### DIFF
--- a/lib/bundleLocator.js
+++ b/lib/bundleLocator.js
@@ -1056,39 +1056,38 @@ BundleLocator.prototype = {
         parentName = self._getBundleNameByPath(libpath.dirname(bundleSeed.baseDirectory));
         parent = self._bundles[parentName];
 
-        return this._makeBundle(bundleSeed, parent).then(function (bundle) {
-            self._bundles[bundle.name] = bundle;
+        function typer(err, path) {
+            var base = libpath.basename(path);
+            if (base.match(/^(?:node_modules$|\.)/) || self._isBuildFile(path)) {
+                return 'ignored';
+            }
+        }
 
+        function queue(err, pathname) {
+            self._fileQueue.push([EVENT_UPDATED, pathname]);
+        }
+
+        function makeBundleResolver(bundle) {
             return new libpromise.Promise(function (fulfill, reject) {
-                var walker = new ScanFS(null, function (err, fullPath) {
-                    var relativePath = libpath.relative(bundle.baseDirectory, fullPath);
-                    if ('node_modules' === relativePath) {
-                        return 'ignored';
-                    }
-                    if ('.' === relativePath.substr(0, 1)) {
-                        return 'ignored';
-                    }
-                });
-                walker.on('file', function (err, fullPath) {
-                    if (!self._isBuildFile(fullPath)) {
-                        self._fileQueue.push([EVENT_UPDATED, fullPath]);
-                    }
-                });
-                walker.on('dir', function (err, fullPath) {
-                    if (!self._isBuildFile(fullPath)) {
-                        self._fileQueue.push([EVENT_UPDATED, fullPath]);
-                    }
-                });
-                walker.on('done', function (err) {
+                function resolveScan(err) {
                     if (err) {
                         reject(err);
                     } else {
                         fulfill(bundle);
                     }
-                });
+                }
+
+                var walker = new ScanFS(null, typer);
+                walker.on('file', queue);
+                walker.on('dir', queue);
+                walker.on('done', resolveScan);
+
+                self._bundles[bundle.name] = bundle;
                 walker.absolutely(bundle.baseDirectory);
             });
-        });
+        }
+
+        return this._makeBundle(bundleSeed, parent).then(makeBundleResolver);
     },
 
 


### PR DESCRIPTION
fixes yahoo/locator#5 by removing the relative path calculation, and uses the basename
to exclude "node_modules" and /^.+/. Plus some minor style tweaks.

checklist:
- [x] locator tests pass (coverage up slightly because of code removal)
- [x] locator-react example works with "location" removed
- [x] <del>locator-react example works with "location" removed _and_ yui-modules dir moved to `examples/node_modules/react-tools`</del> app starts, but this is otherwise non-sensical
- [ ] create fixtures, tests
- [ ] verify against other locator apps
