### PR TITLE
Fix OS dependant path comparison

### DIFF
--- a/lib/bundleLocator.js
+++ b/lib/bundleLocator.js
@@ -390,7 +390,7 @@ BundleLocator.prototype = {
         Object.keys(this._bundlePaths).forEach(function (bundlePath) {
             if (0 === findPath.indexOf(bundlePath) &&
                     (findPath.length === bundlePath.length ||
-                    '/' === findPath.charAt(bundlePath.length))) {
+                    libpath.sep === findPath.charAt(bundlePath.length))) {
                 found[bundlePath.length] = bundlePath;
             }
         });


### PR DESCRIPTION
`bundleLocator` was comparing part of the path of a file with the OS dependant folder separator `'/'`. This was causing the "express-locator" example in `express-yui` to crash on Windows.

Ping @caridy
