### PR TITLE
Porting plugin methods from 0.3.x to 1.0

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -58,5 +58,3 @@ Bundle.prototype = {
 
 
 module.exports = Bundle;
-
-

--- a/lib/bundleLocator.js
+++ b/lib/bundleLocator.js
@@ -136,6 +136,51 @@ BundleLocator.prototype = {
 
 
     /**
+     * Utility method for listing all files in a bundle.
+     * @method getBundleFiles
+     * @param {string} bundleName The name of the bundle.
+     * @param {object} filter Filter for deciding which files to return.
+     * @param {string|[string]} [filter.extensions] The filesystem extensions (NOT including dot) for which files to return.
+     * @return {[string]} An array of filesystem paths.
+     */
+    getBundleFiles: function (bundleName, filter) {
+        var bundle,
+            files = [];
+        bundle = this._bundles[bundleName];
+        if (!bundle) {
+            throw new Error('Unknown bundle "' + bundleName + '"');
+        }
+        Object.keys(bundle.files).forEach(function (fullpath) {
+            var res = {
+                    ext: libpath.extname(fullpath).substr(1)
+                };
+            if (this._filterResource(res, filter)) {
+                files.push(fullpath);
+            }
+        }, this);
+        return files;
+    },
+
+
+    /**
+     * Utility method for listing all resources in a bundle.
+     * @method getBundleResources
+     * @param {string} bundleName The name of the bundle.
+     * @param {object} filter Filter for deciding which resources to return.
+     * @param {string|[string]} [filter.extensions] The filesystem extensions (NOT including dot) for which resources to return.
+     * @param {string|[string]} [filter.types] The resources types for which resources to return.
+     * @return {[string]} An array of filesystem paths.
+     */
+    getBundleResources: function (bundleName, filter) {
+        var bundle = this._bundles[bundleName];
+        if (!bundle) {
+            throw new Error('Unknown bundle "' + bundleName + '"');
+        }
+        return this._walkBundleResources(bundle, filter);
+    },
+
+
+    /**
      * Lists resources in all the bundles.
      * @method listAllResources
      * @param {object} filter Filter for deciding which resources to list.

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -156,6 +156,67 @@ describe('tests/lib/index.js: BundleLocator', function () {
             expect(have).to.deep.equal(want);
         });
 
+        it('getBundleFiles() : filter in bundle', function (next) {
+            var files;
+            try {
+                files = locator.getBundleFiles('Shelf', {extensions: 'js'});
+                // order doesn't matter, since it depends on how the filesystem is walked
+                files.sort();
+                expect(files.length).to.equal(2);
+                expect(files).to.contain(libpath.join(fixture, 'mojits/Shelf/controller.common.js'));
+                expect(files).to.contain(libpath.join(fixture, 'mojits/Shelf/views/index.js'));
+
+                files = locator.getBundleFiles('Read', {extensions: 'css'});
+                // order doesn't matter, since it depends on how the filesystem is walked
+                files.sort();
+                expect(files.length).to.equal(2);
+                expect(files).to.contain(libpath.join(fixture, 'node_modules/modown-lib-read/mojits/Read/assets/read.css'));
+                expect(files).to.contain(libpath.join(fixture, 'node_modules/modown-lib-read/mojits/Read/assets/read.opera-mini.css'));
+
+                next();
+            } catch (err) {
+                next(err);
+            }
+        });
+
+        it('getBundleResources() : filter in bundle', function (next) {
+            var ress;
+            try {
+                ress = locator.getBundleResources('Shelf', {types: 'templates'});
+                // order doesn't matter, since it depends on how the filesystem is walked
+                ress.sort(function (a, b) {
+                    return a.fullPath.localeCompare(b.fullPath);
+                });
+                expect(ress.length).to.equal(2);
+                expect(ress[0]).to.be.an('object');
+                expect(ress[0].bundleName).to.equal('Shelf');
+                expect(ress[0].type).to.equal('templates');
+                expect(ress[0].fullPath).to.equal(libpath.join(fixture, 'mojits/Shelf/templates/index.hb.html'));
+                expect(ress[1]).to.be.an('object');
+                expect(ress[1].bundleName).to.equal('Shelf');
+                expect(ress[1].type).to.equal('templates');
+                expect(ress[1].fullPath).to.equal(libpath.join(fixture, 'mojits/Shelf/templates/index.opera-mini.hb.html'));
+
+                ress = locator.getBundleResources('Read', {extensions: 'css'});
+                // order doesn't matter, since it depends on how the filesystem is walked
+                ress.sort(function (a, b) {
+                    return a.fullPath.localeCompare(b.fullPath);
+                });
+                expect(ress.length).to.equal(2);
+                expect(ress[0]).to.be.an('object');
+                expect(ress[0].bundleName).to.equal('Read');
+                expect(ress[0].ext).to.equal('css');
+                expect(ress[0].fullPath).to.equal(libpath.join(fixture, 'node_modules/modown-lib-read/mojits/Read/assets/read.css'));
+                expect(ress[1]).to.be.an('object');
+                expect(ress[1].bundleName).to.equal('Read');
+                expect(ress[1].ext).to.equal('css');
+                expect(ress[1].fullPath).to.equal(libpath.join(fixture, 'node_modules/modown-lib-read/mojits/Read/assets/read.opera-mini.css'));
+                next();
+            } catch (err) {
+                next(err);
+            }
+        });
+
         it('_getBundleNameByPath()', function () {
             expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits/Weather'))).to.equal('Weather');
             expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits/Weather/x'))).to.equal('Weather');


### PR DESCRIPTION
- `locator.getBundleResources()`: to filter resources per bundle. e.g.: this is used
  by consumers to collect all templates from a given bundle.
- `locator.getBundleFiles()`: to filter files per bundle. e.g.: this is used by consumers
  to collect all css files from a given bundle.
