### PR TITLE
expand path to bundle using fs.realpathSync() for the internal registry to guarantee resolution

### DIFF
--- a/lib/bundleLocator.js
+++ b/lib/bundleLocator.js
@@ -109,7 +109,7 @@ BundleLocator.prototype = {
             var opts = (bundleSeed.baseDirectory === dir) ? options : {};
             self._walkBundle(bundleSeed, opts);
         });
-        this._rootBundleName = this._bundlePaths[dir];
+        this._rootBundleName = this._bundlePaths[libfs.realpathSync(dir)];
         return this._bundles[this._rootBundleName];
     },
 
@@ -252,6 +252,9 @@ BundleLocator.prototype = {
         // FUTURE OPTIMIZATION:  use a more complicated datastructure for faster lookups
         var found = {}, // length: path
             longest;
+        // expands path in case of symlinks
+        findPath = libfs.realpathSync(findPath);
+        // searchs based on expanded path
         Object.keys(this._bundlePaths).forEach(function (bundlePath) {
             if (0 === findPath.indexOf(bundlePath) &&
                     (findPath.length === bundlePath.length ||
@@ -347,7 +350,7 @@ BundleLocator.prototype = {
         bundle.version = seed.version;
         bundle.type = ruleset._name;
         this._bundles[bundle.name] = bundle;
-        this._bundlePaths[bundle.baseDirectory] = bundle.name;
+        this._bundlePaths[libfs.realpathSync(bundle.baseDirectory)] = bundle.name;
 
         // wire into parent
         if (parent) {

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -219,9 +219,11 @@ describe('tests/lib/index.js: BundleLocator', function () {
 
         it('_getBundleNameByPath()', function () {
             expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits/Weather'))).to.equal('Weather');
-            expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits/Weather/x'))).to.equal('Weather');
-            expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits/Weather2'))).to.equal('modown-newsboxes');
-            expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits/Weather2/x'))).to.equal('modown-newsboxes');
+            expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits/Weather/controller.common.js'))).to.equal('Weather');
+            expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits'))).to.equal('modown-newsboxes');
+            expect(locator._getBundleNameByPath(libpath.join(fixture, 'mojits/'))).to.equal('modown-newsboxes');
+            expect(locator._getBundleNameByPath(libpath.join(fixture, 'models/flickr.common.js'))).to.equal('modown-newsboxes');
+            expect(locator._getBundleNameByPath(fixture)).to.equal('modown-newsboxes');
         });
     });
 


### PR DESCRIPTION
This helps when using locator in your app and using `npm link` for some of the bundles. It will be able to resolve and find those pkgs.

This PR should not affect any of the existing users since it is only changing the internal registry. Everything else should remain the same.
