### PR TITLE
Use debug v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "walk": "^2.3.1",
     "semver": "^3.0.1",
-    "debug": "^1.0.4"
+    "debug": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
@drewfish This PR uses version 2 of `debug` 

https://github.com/visionmedia/debug/commit/c61ae82bde19c6fdedfc6684817ff7eb541ff029#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

with the main difference being that it will `use stderr rather than stdout for logging`.   Most of our repos are using v2 - while it's really not a huge deal it'll be one less package to install since everyone else shares a common debug@^2 via npm3