### PR TITLE
[security issue] update semver module to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "npm": ">1.0"
   },
   "dependencies": {
-    "walk": "^2.3.1",
-    "semver": "^3.0.1",
-    "debug": "^2.0.0"
+    "debug": "^2.0.0",
+    "semver": "^5.3.0",
+    "walk": "^2.3.1"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
This updates the `semver` module to the latest to resolve this security issue:
https://nodesecurity.io/advisories/31

*The whitespace change is just from `npm install semver@latest --save`*